### PR TITLE
Run apt-get update with -y

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN echo "deb http://ie.archive.ubuntu.com/ubuntu vivid-security main restricted
 MAINTAINER FRLinux
 
 # Update the default application repository sources list
-RUN apt-get update
+RUN apt-get update -y
 
 # Install debs
 RUN apt-get install -y pcp git build-essential wget npm


### PR DESCRIPTION
Running apt-get update without -y results in various Errors such as
INFO[0002] Error getting container "..." from driver devicemapper: open /dev/mapper/docker-"...": no such file or directory
INFO[0005] Error getting container "..." from driver devicemapper: Error mounting '/dev/mapper/docker-"..."on '/var/lib/docker/devicemapper/mnt/"..."': no such file or directory

If this happens one needs to run 'killall docker' on the host to "reset" these problems.
